### PR TITLE
fix default export

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import logo from './logo.svg';
 import './App.css';
-import { MenuToggle } from './MenuToggle';
+import MenuToggle from './MenuToggle';
 
 
 function App () {

--- a/src/MenuToggle/index.jsx
+++ b/src/MenuToggle/index.jsx
@@ -86,7 +86,7 @@ const ToggleWrapper = styled.span`
   }
 `;
 
-export const MenuToggle = () => {
+const MenuToggle = () => {
 
   const [iconStatus, setIconStatus] = React.useState('default');
 


### PR DESCRIPTION
since you were doing default and named import for the same component I removed the named import part. If you choose to do named import then you probably want to leave out the export default MenuToggle on line 110 in index.js